### PR TITLE
Script: Introduce shell script to resize comicbook file

### DIFF
--- a/cbresize/default.nix
+++ b/cbresize/default.nix
@@ -1,0 +1,53 @@
+{
+  stdenvNoCC,
+  lib,
+  writeShellScript,
+  imagemagick,
+  unzip,
+  zip,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "cbresize";
+  version = "0.1.0";
+  src = ./.;
+
+  # Use writeScript to create the script
+  script = writeShellScript "cbresize" ''
+    # get input file
+    input=$1
+    basename=$(basename "$input")
+    result=$(pwd)/$basename
+    echo $input
+    echo $basename
+    echo $result
+
+    # create temporary directory to store extracted images
+    tmpdir=$(mktemp --directory)
+    echo $tmpdir
+
+    # extract images into temporary directory
+    unzip -j -d $tmpdir "$input"
+
+    # resize images with imagemagick
+    mogrify -resize x1200 -quality 100 "$tmpdir/*"
+
+    # package images into comicbook
+    zip "$result" -j -r $tmpdir
+    echo $result
+
+    # cleanup
+    rm -fr $tmpdir
+  '';
+
+  # The script is already executable, so we don't need to set permissions
+  installPhase = ''
+    mkdir -p $out/bin
+    cp ${script} $out/bin/cbresize
+  '';
+
+  meta = with lib; {
+    description = "Resize comicbook to save space";
+    license = licenses.mit;
+  };
+}

--- a/cbresize/default.nix
+++ b/cbresize/default.nix
@@ -3,13 +3,14 @@
   lib,
   writeShellScript,
   imagemagick,
+  parallel,
   unzip,
   zip,
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "cbresize";
-  version = "0.1.0";
+  version = "0.2.0";
   src = ./.;
 
   # Use writeScript to create the script
@@ -30,7 +31,7 @@ stdenvNoCC.mkDerivation rec {
     unzip -j -d $tmpdir "$input"
 
     # resize images with imagemagick
-    mogrify -resize x1200 -quality 100 "$tmpdir/*"
+    ${parallel}/bin/parallel mogrify -resize x1600 -quality 100 ::: $tmpdir/*
 
     # package images into comicbook
     zip "$result" -j -r $tmpdir

--- a/home.nix
+++ b/home.nix
@@ -74,6 +74,7 @@
 
     # Custom packages
     (callPackage ./cbr2cbz/default.nix { })
+    (callPackage ./cbresize/default.nix { })
     (callPackage ./phpstorm-cli-wrapper/default.nix { })
     (callPackage ./phpstorm-url-handler/default.nix { })
   ];


### PR DESCRIPTION
Close GH-8

## Missing features
- [ ] overwrite original file
  - [ ] skip if input has lower resolution than target
  - [ ] skip if resulted resized file is not significantly smaller
- [ ] option to change target image size (default: x1600)
- [ ] option to select image format (default: same as input)